### PR TITLE
configurable sleep time 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM docker:latest
 LABEL maintainer "djimaze"
-COPY shepherd /usr/local/bin/shepherd
+ENV sleep_time='5m'
 
-ENTRYPOINT ["/usr/local/bin/shepherd"]
+COPY shepherd /usr/local/bin/shepherd
+ENTRYPOINT ["/usr/local/bin/shepherd","$sleep_time"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ LABEL maintainer "djimaze"
 ENV SLEEPTIME='5m'
 
 COPY shepherd /usr/local/bin/shepherd
-ENTRYPOINT ["/usr/local/bin/shepherd","$SLEEPTIME"]
+ENTRYPOINT ["/usr/local/bin/shepherd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:latest
 LABEL maintainer "djimaze"
-ENV sleep_time='5m'
+ENV SLEEPTIME='5m'
 
 COPY shepherd /usr/local/bin/shepherd
-ENTRYPOINT ["/usr/local/bin/shepherd","$sleep_time"]
+ENTRYPOINT ["/usr/local/bin/shepherd","$SLEEPTIME"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM docker
-
+FROM docker:latest
+LABEL maintainer "djimaze"
 COPY shepherd /usr/local/bin/shepherd
 
 ENTRYPOINT ["/usr/local/bin/shepherd"]

--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ A Docker swarm service for automatically updating your services whenever their b
     docker service create --name shepherd \
                           --replicas 1 \
                           --constraint "node.role==manager" \
+                          --env SLEEPTIME='5m" \
+                          --mount type=bind,source=/path_to_blacklist_file,target=/tmp,ro \
                           --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,ro \
                           mazzolino/shepherd
 
-Shepherd will try to update your services every 5 minutes.
+Shepherd will try to update your services every 5 minutes but you can change this value by chengin the value of the SLEEPTIME variable.
+if you want to blacklist a service or more than one add the name of the services (one per line ) in a file called blacklist and mount it  as describe in the Usage example
 
 ## How does it work?
 

--- a/shepherd
+++ b/shepherd
@@ -17,7 +17,8 @@ update_services() {
 main() {
   while true; do
     update_services
-    sleep 5m
+    echo "sleeping ${sleep_time} before new update"
+    sleep "${sleep_time}"
   done
 }
 

--- a/shepherd
+++ b/shepherd
@@ -17,8 +17,8 @@ update_services() {
 main() {
   while true; do
     update_services
-    echo "sleeping ${sleep_time} before new update"
-    sleep "${sleep_time}"
+    echo "sleeping ${SLEEPTIME} before new update"
+    sleep "${SLEEPTIME}"
   done
 }
 

--- a/shepherd
+++ b/shepherd
@@ -9,11 +9,13 @@ update_services() {
     local name image_with_digest image present
     present=0
     name="$(docker service inspect "$service" -f '{{.Spec.Name}}')"
-    for blacklisted in $(IFS="\n" cat /tmp/blacklist); do
+    if [ -f /tmp/blacklist ]; then
+     for blacklisted in $(IFS="\n" cat /tmp/blacklist); do
       if [ "$blacklisted" == "$name" ]; then
        present=1
       fi
-    done
+     done
+    fi 
     if [ "$present" -eq "0" ]; then
      image_with_digest="$(docker service inspect "$service" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
      image=$(echo "$image_with_digest" | cut -d@ -f1)

--- a/shepherd
+++ b/shepherd
@@ -2,22 +2,33 @@
 # shellcheck shell=dash
 set -euo pipefail
 
+#sleep_time="$1"
+
 update_services() {
   for service in $(IFS="\n" docker service ls --quiet); do
-    local name image_with_digest image
+    local name image_with_digest image present
+    present=0
     name="$(docker service inspect "$service" -f '{{.Spec.Name}}')"
-    image_with_digest="$(docker service inspect "$service" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
-    image=$(echo "$image_with_digest" | cut -d@ -f1)
-
-    echo "Updating service $name with image $image"
-    docker service update "$service" --image "$image" > /dev/null
+    for blacklisted in $(IFS="\n" cat /tmp/blacklist); do
+      if [ "$blacklisted" == "$name" ]; then
+       present=1
+      fi
+    done
+    if [ "$present" -eq "0" ]; then
+     image_with_digest="$(docker service inspect "$service" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
+     image=$(echo "$image_with_digest" | cut -d@ -f1)
+     echo "Updating service $name with image $image"
+     docker service update --detach="false" "$service" --image="$image" > /dev/null
+    else
+     echo "service ${name} is blacklisted .... skipping"
+   fi
   done
 }
 
 main() {
   while true; do
     update_services
-    echo "sleeping ${SLEEPTIME} before new update"
+    echo "sleeping ${SLEEPTIME} before new update."
     sleep "${SLEEPTIME}"
   done
 }

--- a/shepherd
+++ b/shepherd
@@ -2,8 +2,6 @@
 # shellcheck shell=dash
 set -euo pipefail
 
-#sleep_time="$1"
-
 update_services() {
   for service in $(IFS="\n" docker service ls --quiet); do
     local name image_with_digest image present
@@ -13,6 +11,7 @@ update_services() {
      for blacklisted in $(IFS="\n" cat /tmp/blacklist); do
       if [ "$blacklisted" == "$name" ]; then
        present=1
+       break
       fi
      done
     fi 


### PR DESCRIPTION
Sleep time will be 5m by default but can be changed with env variable like 

docker service create --name shepherd \
                      --replicas 1 \
                      --constraint "node.role==manager" \
                      **--env  sleep_time='180m'   \**
                      --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,ro \
                      mazzolino/shepherd
