### PR TITLE
Fixes for 0.2

### DIFF
--- a/shepherd
+++ b/shepherd
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+server_version() {
+  docker version -f "{{.Server.Version}}"
+}
+
 update_services() {
   local blacklist="$1"
+  local supports_detach_option=$2
+  local detach_option=""
+  [ $supports_detach_option = true ] && detach_option="--detach=false"
 
   for service in $(IFS="\n" docker service ls --quiet); do
     local name image_with_digest image
@@ -11,19 +18,26 @@ update_services() {
       image_with_digest="$(docker service inspect "$service" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
       image=$(echo "$image_with_digest" | cut -d@ -f1)
       echo "Updating service $name with image $image"
-      docker service update "$service" --detach=false --image="$image" > /dev/null
+      docker service update "$service" $detach_option --image="$image" > /dev/null
     fi
   done
 }
 
 main() {
-  local blacklist="${BLACKLIST_SERVICES:-}"
+  local blacklist supports_detach_option=false
+  blacklist="${BLACKLIST_SERVICES:-}"
+
+  if [[ "$(server_version)" > "17.05" ]]; then
+    supports_detach_option=true
+    echo "Enabling synchronous service updates"
+  fi
+
   [[ "$blacklist" != "" ]] && echo "Excluding services: $blacklist"
 
   while true; do
-    update_services "${blacklist}"
-    echo "Sleeping ${SLEEP_TIME} before next update"
-    sleep "${SLEEP_TIME}"
+    update_services "$blacklist" "$supports_detach_option"
+    echo "Sleeping $SLEEP_TIME before next update"
+    sleep "$SLEEP_TIME"
   done
 }
 

--- a/shepherd
+++ b/shepherd
@@ -24,20 +24,24 @@ update_services() {
 }
 
 main() {
-  local blacklist supports_detach_option=false
+  local blacklist sleep_time supports_detach_option
   blacklist="${BLACKLIST_SERVICES:-}"
+  sleep_time="${SLEEP_TIME:-5m}"
 
+  supports_detach_option=false
   if [[ "$(server_version)" > "17.05" ]]; then
     supports_detach_option=true
     echo "Enabling synchronous service updates"
+  else
+    supports_detach_option=false
   fi
 
   [[ "$blacklist" != "" ]] && echo "Excluding services: $blacklist"
 
   while true; do
     update_services "$blacklist" "$supports_detach_option"
-    echo "Sleeping $SLEEP_TIME before next update"
-    sleep "$SLEEP_TIME"
+    echo "Sleeping $sleep_time before next update"
+    sleep "$sleep_time"
   done
 }
 


### PR DESCRIPTION
- The `detach` option has been added in [17.05](https://github.com/moby/moby/blob/9ff8068ca2bb1ba308ceec8f6a6ccb0fe7e7e746/docs/deprecated.md#asynchronous-service-create-and-service-update). Make sure not to use it on an older server version
- The service wasn't working when `SLEEP_TIME` was unset