### PR TITLE
Support for private registry authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,15 @@ Shepherd will try to update your services every 5 minutes by default. You can ad
 
 You can prevent services from being updated bei appending them to the `BLACKLIST_SERVICES` variable. This should be a space-separated list of service names.
 
+You can enable private registry authentication by setting the `WITH_REGISTRY_AUTH` variable.
+
 Example:
 
     docker service create --name shepherd \
                         --constraint "node.role==manager" \
                         --env SLEEP_TIME="5m" \
                         --env BLACKLIST_SERVICES="shepherd my-other-service" \
+                        --env WITH_REGISTRY_AUTH \
                         --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,ro \
                         mazzolino/shepherd
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Example:
                         --constraint "node.role==manager" \
                         --env SLEEP_TIME="5m" \
                         --env BLACKLIST_SERVICES="shepherd my-other-service" \
-                        --env WITH_REGISTRY_AUTH \
+                        --env WITH_REGISTRY_AUTH="true" \
                         --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,ro \
+                        --mount type=bind,source=/root/.docker/config.json,target=/root/.docker/config.json,ro \
                         mazzolino/shepherd
 
 ## How does it work?

--- a/shepherd
+++ b/shepherd
@@ -8,8 +8,12 @@ server_version() {
 update_services() {
   local blacklist="$1"
   local supports_detach_option=$2
+  local supports_registry_auth=$3
   local detach_option=""
+  local registry_auth=""
+
   [ $supports_detach_option = true ] && detach_option="--detach=false"
+  [ $supports_registry_auth = true ] && registry_auth="--with-registry-auth"
 
   for service in $(IFS="\n" docker service ls --quiet); do
     local name image_with_digest image
@@ -18,13 +22,13 @@ update_services() {
       image_with_digest="$(docker service inspect "$service" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
       image=$(echo "$image_with_digest" | cut -d@ -f1)
       echo "Updating service $name with image $image"
-      docker service update "$service" $detach_option --image="$image" > /dev/null
+      docker service update "$service" $detach_option $registry_auth --image="$image" > /dev/null
     fi
   done
 }
 
 main() {
-  local blacklist sleep_time supports_detach_option
+  local blacklist sleep_time supports_detach_option supports_registry_auth
   blacklist="${BLACKLIST_SERVICES:-}"
   sleep_time="${SLEEP_TIME:-5m}"
 
@@ -32,17 +36,23 @@ main() {
   if [[ "$(server_version)" > "17.05" ]]; then
     supports_detach_option=true
     echo "Enabling synchronous service updates"
-  else
-    supports_detach_option=false
+  fi
+
+  supports_registry_auth=false
+  if [[ ${WITH_REGISTRY_AUTH+x} ]]; then
+    supports_registry_auth=true
+    echo "Send registry authentication details to swarm agents"
   fi
 
   [[ "$blacklist" != "" ]] && echo "Excluding services: $blacklist"
 
   while true; do
-    update_services "$blacklist" "$supports_detach_option"
+    update_services "$blacklist" "$supports_detach_option" "$supports_registry_auth"
     echo "Sleeping $sleep_time before next update"
     sleep "$sleep_time"
   done
+
+  
 }
 
 main "$@"

--- a/shepherd
+++ b/shepherd
@@ -51,8 +51,6 @@ main() {
     echo "Sleeping $sleep_time before next update"
     sleep "$sleep_time"
   done
-
-  
 }
 
 main "$@"


### PR DESCRIPTION
This PR includes a change by @pdeveltere and a README enhancement by me. It allows using shepherd for private registries.

Tested with Docker 18.03.0-ce. Closes #6 