### PR TITLE
feat: add 'manual mode'

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ Example:
                         --mount type=bind,source=/root/.docker/config.json,target=/root/.docker/config.json,ro \
                         mazzolino/shepherd
 
-## How does it work?
+#### Manual mode
+
+It is recommended to let Docker use its built-in _image resolution and pulling logic_, particularly if your Swarm has more than a single node, but if such logic is not working as you expect (i.e images are pulled without tags), you can try enabling the _manual mode_. Shepherd will manually pull locally the latest tagged image from the registry, check if its newer compared to the one in use by the service (by comparing their unique identifiers, called _digests_), and in such case it will try and force Docker to update the service with it.
+
+You can enable the _manual mode_ for every non-blacklisted service by setting the environment variable `MANUAL_MODE: "all"` on Shepherd service, or instead you can add the label `MANUAL_MODE: "true"` (include the quotes) just to certain services.
+
+## How does Shepherd work?
 
 Shepherd just triggers updates by updating the image specification for each service, removing the current digest.
 

--- a/shepherd
+++ b/shepherd
@@ -5,30 +5,101 @@ server_version() {
   docker version -f "{{.Server.Version}}"
 }
 
+# Runs `docker service inspect` with output formatting.
+# @param {string} service The service name
+# @param {string} format The format string
+service_inspect() {
+  local service="$1"
+  local format="$2"
+
+  docker service inspect "$service" -f "$format"
+}
+
 update_services() {
   local blacklist="$1"
   local supports_detach_option=$2
   local supports_registry_auth=$3
+  local manual_mode_for_all=$4
   local detach_option=""
   local registry_auth=""
+  local label_manual_mode="com.shepherd.manual_mode"
 
   [ $supports_detach_option = true ] && detach_option="--detach=false"
   [ $supports_registry_auth = true ] && registry_auth="--with-registry-auth"
 
   for service in $(IFS="\n" docker service ls --quiet); do
-    local name image_with_digest image
-    name="$(docker service inspect "$service" -f '{{.Spec.Name}}')"
+    local name service_image_with_digest service_image service_image_digest service_has_manual_mode
+    service_has_manual_mode=false
+
+    name="$(service_inspect "$service" '{{.Spec.Name}}')"
     if [[ " $blacklist " != *" $name "* ]]; then
-      image_with_digest="$(docker service inspect "$service" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
-      image=$(echo "$image_with_digest" | cut -d@ -f1)
-      echo "Updating service $name with image $image"
-      docker service update "$service" $detach_option $registry_auth --image="$image" > /dev/null
+      # Format: [organization]/[repository]:[tag]@sha256:[checksum]
+      service_image_with_digest=$(service_inspect "$service" '{{.Spec.TaskTemplate.ContainerSpec.Image}}')
+      # Format: [organization]/[repository]:[tag]
+      service_image=$(echo "$service_image_with_digest" | cut -d@ -f1)
+      # Format: sha256:[checksum]
+      service_image_digest=$(echo "$service_image_with_digest" | cut -d@ -f2)
+
+      # Is "manual mode" enabled for all services via environment variable?
+      if [[ "$manual_mode_for_all" == true ]]; then service_has_manual_mode=true; fi
+      # ... otherwise, is "manual mode" enabled for this service via service label?
+      if [[ "$service_has_manual_mode" == false ]]; then
+        service_has_manual_mode=$(service_inspect "$service" '{{index .Spec.TaskTemplate.ContainerSpec.Labels "'"$label_manual_mode"'"}}')
+      fi
+
+      if [[ "$service_has_manual_mode" == true ]]; then
+        # We do not rely on Docker's image resolution and pulling logic to turn:
+        # `[organization]/[repository]:[tag]`
+        # ... into the latest: `[organization]/[repository]:[tag]@sha256:[checksum]`
+        # ... to then pull that image and update the service `$service` with it.
+        local local_image_with_digest local_image_digest
+
+        # This command is straightforward, it pulls the latest tagged image locally
+        # It also works with private repository images, if the correct volumes are
+        # mounted and `docker login` was executed on the host.
+        docker pull "$service_image" > /dev/null
+
+        # Format: [organization]/[repository]@sha256:[checksum]
+        local_image_with_digest=$(docker image inspect "$service_image" -f '{{index .RepoDigests 0}}')
+        # Format: sha256:[checksum]
+        local_image_digest=$(echo "$local_image_with_digest" | cut -d@ -f2)
+
+        # Check if the service's image has become outdated after `docker pull`,
+        # by comparing its digest with the digest of the local image.
+        if [[ "$service_image_digest" != "$local_image_digest" ]]; then
+          # We need to update the service and make it load the latest image, the
+          # one we pulled locally a few lines above.
+          local service_new_image_with_digest
+
+          # Format: [organization]/[repository]:[tag]@sha256:[checksum]
+          service_new_image_with_digest="${service_image}@${local_image_digest}"
+
+          echo "Updating service $name with image $service_image"
+          echo "Image with digest: $service_new_image_with_digest"
+
+          # 1) We exclude `$registry_auth` because the image has been pulled locally.
+          # 2) We specify the exact image name/tag/digest, to force Docker to select it.
+          # 3) We "force" the update since we know the service must be updated.
+          # 4) If the udpate is successful, the following command returns $service_new_image_with_digest:
+          #   `docker service inspect [service] -f "{{.Spec.TaskTemplate.ContainerSpec.Image}}"`
+          # 5) If the update is successful and you are not affected by a bug or a
+          # configuration issue, all the container tasks belonging to the service
+          # should return $service_new_image_with_digest when executing:
+          #   `docker inspect "[container_of_service]" -f {{.Config.Image}}`
+          docker service update "$service" $detach_option --image="$service_new_image_with_digest" --force > /dev/null
+        fi
+      else
+        # Default behavior: we let `docker service update --image` use Docker's
+        # built-in image resolution and pulling logic.
+        echo "Updating service $name with image $service_image"
+        docker service update "$service" $detach_option $registry_auth --image="$service_image" > /dev/null
+      fi
     fi
   done
 }
 
 main() {
-  local blacklist sleep_time supports_detach_option supports_registry_auth
+  local blacklist sleep_time supports_detach_option supports_registry_auth manual_mode_for_all
   blacklist="${BLACKLIST_SERVICES:-}"
   sleep_time="${SLEEP_TIME:-5m}"
 
@@ -44,10 +115,23 @@ main() {
     echo "Send registry authentication details to swarm agents"
   fi
 
+  manual_mode_for_all=false
+  # Check if the variable is defined first.
+  if [[ ${MANUAL_MODE+x} ]]; then
+    if [[ "$MANUAL_MODE" == "all" ]]; then
+        manual_mode_for_all=true
+        echo "Enabling manual mode for all services"
+      else
+        # Warn an user who may have written something like "true".
+        echo "Error: the value of variable 'MANUAL_MODE' is unrecognized"
+        exit 1
+    fi
+  fi
+
   [[ "$blacklist" != "" ]] && echo "Excluding services: $blacklist"
 
   while true; do
-    update_services "$blacklist" "$supports_detach_option" "$supports_registry_auth"
+    update_services "$blacklist" "$supports_detach_option" "$supports_registry_auth" "$manual_mode_for_all"
     echo "Sleeping $sleep_time before next update"
     sleep "$sleep_time"
   done


### PR DESCRIPTION
When "manual mode" is enabled, Shepherd will manually pull locally the latest tagged image from the registry, check if its newer compared to the one in use by the service (by comparing their unique identifiers, called _digests_), and in such case it will try and force Docker to update the service with it.

This feature has been initially developed to have a temporary workaround/alternative until the "pulled images with none tag" issue is fixed: SEE: https://github.com/moby/moby/issues/28908

It could also be used to isolate and troubleshoot issues that one thinks may be related to the "update process", by setting some services in "manual mode" and monitoring their status, compared to the ones updated fully using the built-in logic and not "forcing".

Includes:
- Add "manual mode" feature to the main script.
- Update the README.
- Add more comments to the code.

May also help with #8.

I have tested this in a live setup and locally with a super basic single-node Swarm stack that uses both a private and public image (global and replicated), that I both re-build and push to the registry  in-between shepherd runs, using a simple shell script and Dockerfile.