### PR TITLE
Filtering services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker
 
 ENV SLEEP_TIME='5m'
+ENV FILTER_SERVICES=''
 
 RUN apk add --update --no-cache bash
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Shepherd will try to update your services every 5 minutes by default. You can ad
 
 You can prevent services from being updated by appending them to the `BLACKLIST_SERVICES` variable. This should be a space-separated list of service names.
 
+Alternatively you can specify a filter for the services you want updated using the `FILTER_SERVICES` variable. This can be anything accepted by the filtering flag in `docker service ls`.
+
 You can enable private registry authentication by setting the `WITH_REGISTRY_AUTH` variable.
 
 Example:
@@ -38,6 +40,7 @@ Example:
                         --env SLEEP_TIME="5m" \
                         --env BLACKLIST_SERVICES="shepherd my-other-service" \
                         --env WITH_REGISTRY_AUTH="true" \
+                        --env FILTER_SERVICES="label=com.mydomain.autodeploy"
                         --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,ro \
                         --mount type=bind,source=/root/.docker/config.json,target=/root/.docker/config.json,ro \
                         mazzolino/shepherd

--- a/shepherd
+++ b/shepherd
@@ -15,7 +15,7 @@ update_services() {
   [ $supports_detach_option = true ] && detach_option="--detach=false"
   [ $supports_registry_auth = true ] && registry_auth="--with-registry-auth"
 
-  for service in $(IFS="\n" docker service ls --quiet); do
+  for service in $(IFS="\n" docker service ls --quiet --filter "${FILTER_SERVICES}"); do
     local name image_with_digest image
     name="$(docker service inspect "$service" -f '{{.Spec.Name}}')"
     if [[ " $blacklist " != *" $name "* ]]; then


### PR DESCRIPTION
This would allow for filtering the list of services to update using a `FILTER_SERVICES` env var. It should work with any value you can give to the `--filter` option in `docker service ls`. For example, if you only want to update services with an `autodeploy` label, set `FILTER_SERVICES="label=autodeploy"`. This might resolve #9.