### PR TITLE
NO_VERBOSE option for showing useful logs only

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Alternatively you can specify a filter for the services you want updated using t
 
 You can enable private registry authentication by setting the `WITH_REGISTRY_AUTH` variable.
 
+`NO_VERBOSE` variable can disable info messages like "Trying to update ..." and "No updates to service ...".
+
 Example:
 
     docker service create --name shepherd \
@@ -43,8 +45,9 @@ Example:
                         --env SLEEP_TIME="5m" \
                         --env BLACKLIST_SERVICES="shepherd my-other-service" \
                         --env WITH_REGISTRY_AUTH="true" \
-                        --env FILTER_SERVICES="label=com.mydomain.autodeploy"
-                        --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,ro \
+                        --env FILTER_SERVICES="label=com.mydomain.autodeploy" \
+                        --env NO_VERBOSE="true" \
+                        --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
                         --mount type=bind,source=/root/.docker/config.json,target=/root/.docker/config.json,ro \
                         mazzolino/shepherd
 

--- a/shepherd
+++ b/shepherd
@@ -21,13 +21,13 @@ update_services() {
     if [[ " $blacklist " != *" $name "* ]]; then
       image_with_digest="$(docker service inspect "$service" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
       image=$(echo "$image_with_digest" | cut -d@ -f1)
-      echo "Trying to update service $name with image $image"
+      [ "$NO_VERBOSE" = "true" ] || echo "Trying to update service $name with image $image"
       docker service update "$service" $detach_option $registry_auth --image="$image" > /dev/null
 
       previousImage=$(docker service inspect "$service" -f '{{.PreviousSpec.TaskTemplate.ContainerSpec.Image}}')
       currentImage=$(docker service inspect "$service" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')
       if [ "$previousImage" == "$currentImage" ]; then
-        echo "No updates to service $name!"
+        [ "$NO_VERBOSE" = "true" ] || echo "No updates to service $name!"
       else
         echo "Service $name was updated!"
       fi


### PR DESCRIPTION
shepherd generates to much useless logs. Added option can disable messages like:
- Trying to update service ...
- No updates to service ...

Also added minor fixes in README.