### PR TITLE
Add timestamp to output

### DIFF
--- a/shepherd
+++ b/shepherd
@@ -22,15 +22,15 @@ update_services() {
     if [[ " $blacklist " != *" $name "* ]]; then
       image_with_digest="$(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
       image=$(echo "$image_with_digest" | cut -d@ -f1)
-      echo "Trying to update service $name with image $image"
+      echo "$(date -Iseconds) Trying to update service $name with image $image"
       docker service update "$name" $detach_option $registry_auth --image="$image" > /dev/null
 
       previousImage=$(docker service inspect "$name" -f '{{.PreviousSpec.TaskTemplate.ContainerSpec.Image}}')
       currentImage=$(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')
       if [ "$previousImage" == "$currentImage" ]; then
-        echo "No updates to service $name!"
+        echo "$(date -Iseconds) No updates to service $name!"
       else
-        echo "Service $name was updated!"
+        echo "$(date -Iseconds) Service $name was updated!"
         if [[ "$apprise_sidecar_url" != "" ]]; then
           title="[Shepherd] Service $name updated"
           body="Service $name was updated from $previousImage to $currentImage"
@@ -49,20 +49,20 @@ main() {
   supports_detach_option=false
   if [[ "$(server_version)" > "17.05" ]]; then
     supports_detach_option=true
-    echo "Enabling synchronous service updates"
+    echo "$(date -Iseconds) Enabling synchronous service updates"
   fi
 
   supports_registry_auth=false
   if [[ ${WITH_REGISTRY_AUTH+x} ]]; then
     supports_registry_auth=true
-    echo "Send registry authentication details to swarm agents"
+    echo "$(date -Iseconds) Send registry authentication details to swarm agents"
   fi
 
-  [[ "$blacklist" != "" ]] && echo "Excluding services: $blacklist"
+  [[ "$blacklist" != "" ]] && echo "$(date -Iseconds) Excluding services: $blacklist"
 
   while true; do
     update_services "$blacklist" "$supports_detach_option" "$supports_registry_auth"
-    echo "Sleeping $sleep_time before next update"
+    echo "$(date -Iseconds) Sleeping $sleep_time before next update"
     sleep "$sleep_time"
   done
 }


### PR DESCRIPTION
Add a timestamp to all output. This would help when checking when a service was updated.