### PR TITLE
Renames BLACKLIST_SERVICES variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A Docker swarm service for automatically updating your services whenever their b
 
 Shepherd will try to update your services every 5 minutes by default. You can adjust this value using the `SLEEP_TIME` variable.
 
-You can prevent services from being updated by appending them to the `BLACKLIST_SERVICES` variable. This should be a space-separated list of service names.
+You can prevent services from being updated by appending them to the `IGNORELIST_SERVICES` variable. This should be a space-separated list of service names.
 
 Alternatively you can specify a filter for the services you want updated using the `FILTER_SERVICES` variable. This can be anything accepted by the filtering flag in `docker service ls`.
 
@@ -51,7 +51,7 @@ Example:
     docker service create --name shepherd \
                         --constraint "node.role==manager" \
                         --env SLEEP_TIME="5m" \
-                        --env BLACKLIST_SERVICES="shepherd my-other-service" \
+                        --env IGNORELIST_SERVICES="shepherd my-other-service" \
                         --env WITH_REGISTRY_AUTH="true" \
                         --env WITH_INSECURE_REGISTRY="true" \
                         --env WITH_NO_RESOLVE_IMAGE="true" \

--- a/shepherd
+++ b/shepherd
@@ -15,7 +15,7 @@ logger() {
 }
 
 update_services() {
-  local blacklist="$1"
+  local ignorelist="$1"
   local supports_detach_option=$2
   local supports_registry_auth=$3
   local supports_insecure_registry=$4
@@ -35,7 +35,7 @@ update_services() {
 
   for name in $(IFS=$'\n' docker service ls --quiet --filter "${FILTER_SERVICES}" --format '{{.Name}}'); do
     local image_with_digest image
-    if [[ " $blacklist " != *" $name "* ]]; then
+    if [[ " $ignorelist " != *" $name "* ]]; then
       image_with_digest="$(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
       image=$(echo "$image_with_digest" | cut -d@ -f1)
 
@@ -75,8 +75,8 @@ update_services() {
 }
 
 main() {
-  local blacklist sleep_time supports_detach_option supports_registry_auth tz verbose image_autoclean_limit
-  blacklist="${BLACKLIST_SERVICES:-}"
+  local sleep_time supports_detach_option supports_registry_auth tz verbose image_autoclean_limit ignorelist
+  ignorelist="${IGNORELIST_SERVICES:-}"
   sleep_time="${SLEEP_TIME:-5m}"
   verbose="${VERBOSE:-true}"
   image_autoclean_limit="${IMAGE_AUTOCLEAN_LIMIT:-}"
@@ -107,13 +107,13 @@ main() {
     logger "Deployment without resolving image"
   fi
 
-  [[ "$blacklist" != "" ]] && logger "Excluding services: $blacklist"
+  [[ "$ignorelist" != "" ]] && logger "Excluding services: $ignorelist"
 
   if [[ ${RUN_ONCE_AND_EXIT+x} ]]; then
-    update_services "$blacklist" "$supports_detach_option" "$supports_registry_auth" "$supports_insecure_registry" "$supports_no_resolve_image" "$image_autoclean_limit"
+    update_services "$ignorelist" "$supports_detach_option" "$supports_registry_auth" "$supports_insecure_registry" "$supports_no_resolve_image" "$image_autoclean_limit"
   else
     while true; do
-      update_services "$blacklist" "$supports_detach_option" "$supports_registry_auth" "$supports_insecure_registry" "$supports_no_resolve_image" "$image_autoclean_limit"
+      update_services "$ignorelist" "$supports_detach_option" "$supports_registry_auth" "$supports_insecure_registry" "$supports_no_resolve_image" "$image_autoclean_limit"
       logger "Sleeping $sleep_time before next update" "true"
       sleep "$sleep_time"
     done


### PR DESCRIPTION
Hello,

first of all, congrats for the job with shepherd, it helps a lot the CI/CD environment on PencilLabs, a tech brazilian company that i'm cofounder and developer.

This MR renames the `BLACKLIST_SERVICES`  env variable to `IGNORELIST_SERVICES`. As a black man and developer we must avoid using racist terms that the tech industry for so long has normalized. At Pencillabs, our swarm cluster already is using a custom shepherd image with `IGNORELIST_SERVICES`, so we can tag a shepherd version with `BLACKLIST_SERVICES`, to avoid breaking other environments.