### PR TITLE
Add support for rolling back on a failed update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ You can prevent services from being updated by appending them to the `IGNORELIST
 
 Alternatively you can specify a filter for the services you want updated using the `FILTER_SERVICES` variable. This can be anything accepted by the filtering flag in `docker service ls`.
 
+You can set Shepherd to roll back a service to the previous version if the update fails by setting the `ROLLBACK_ON_FAILURE` variable.
+
 You can enable private registry authentication by setting the `WITH_REGISTRY_AUTH` variable.
 
 You can enable connection to insecure private registry by setting the `WITH_INSECURE_REGISTRY` variable.
@@ -59,6 +61,7 @@ Example:
                         --env APPRISE_SIDECAR_URL="apprise-microservice:5000" \
                         --env IMAGE_AUTOCLEAN_LIMIT="5" \
                         --env RUN_ONCE_AND_EXIT="true" \
+                        --env ROLLBACK_ON_FAILURE="true" \
                         --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,ro \
                         --mount type=bind,source=/root/.docker/config.json,target=/root/.docker/config.json,ro \
                         mazzolino/shepherd

--- a/shepherd
+++ b/shepherd
@@ -44,7 +44,9 @@ update_services() {
       else
         logger "Trying to update service $name with image $image" "true"
 
-        docker service update "$name" $detach_option $registry_auth $no_resolve_image_flag --image="$image" > /dev/null
+        if ! docker service update "$name" $detach_option $registry_auth $no_resolve_image_flag --image="$image" > /dev/null; then
+          logger "Service $name update failed!"
+        fi
 
         previousImage=$(docker service inspect "$name" -f '{{.PreviousSpec.TaskTemplate.ContainerSpec.Image}}')
         currentImage=$(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')

--- a/shepherd
+++ b/shepherd
@@ -46,6 +46,15 @@ update_services() {
 
         if ! docker service update "$name" $detach_option $registry_auth $no_resolve_image_flag --image="$image" > /dev/null; then
           logger "Service $name update failed!"
+          if [[ "${ROLLBACK_ON_FAILURE+x}" ]]; then
+            logger "Rolling $name back"
+            docker service update "$name" $detach_option $registry_auth $no_resolve_image_flag --rollback > /dev/null
+          fi
+          if [[ "$apprise_sidecar_url" != "" ]]; then
+            title="[Shepherd] Service $name update failed"
+            body="$(date) Service $name failed to update to $(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
+            curl -X POST -H "Content-Type: application/json" --data "{\"title\": \"$title\", \"body\": \"$body\"}" "$apprise_sidecar_url"
+          fi
         fi
 
         previousImage=$(docker service inspect "$name" -f '{{.PreviousSpec.TaskTemplate.ContainerSpec.Image}}')


### PR DESCRIPTION
`docker service update` will exit with `1` and write something like `service update paused: update paused due to failure or early termination of task ...` to stderr if the updated service fails to start or remains unhealthy.

By setting the `ROLLBACK_ON_FAILURE` variable if an update fails Shepherd will roll it[1] back to the previous version, thus avoiding a service failure as a result of the update. If the Apprise Sidecar is set it will also send a notification about this.

[1]: https://docs.docker.com/engine/reference/commandline/service_update/#roll-back-to-the-previous-version-of-a-service