### PR TITLE
support auth to multiple regs in secret file

### DIFF
--- a/shepherd
+++ b/shepherd
@@ -13,6 +13,27 @@ logger() {
     echo "$(date) $log"
   fi
 }
+authenticate_to_registries() {
+  local config host user password
+  if [[ -n "$registry_user" ]]; then
+    logger "Trying to login into registry $registry_host"
+    echo "$registry_password" | docker login --username="$registry_user" --password-stdin "$registry_host"
+  fi
+  if [[ -n "${REGISTRIES_FILE:-""}" ]]; then
+    while IFS=$'\t' read -r -a reg_info; do
+      # skip comments and invalid lines
+      if [[ "${reg_info[0]}" =~ "#" ]] || [[ ${#reg_info[@]} -ne 4 ]] ; then
+          continue
+      fi
+      config="${reg_info[0]}"
+      host="${reg_info[1]}"
+      user="${reg_info[2]}"
+      password="${reg_info[3]}"
+      logger "Trying to login into registry $host for config $config with user $user"
+      echo "$password" | docker --config "$config" login --username="$user" --password-stdin "$host"
+    done <"$REGISTRIES_FILE"
+  fi
+}
 
 update_services() {
   local ignorelist="$1"
@@ -38,29 +59,32 @@ update_services() {
   [ "$supports_insecure_registry" = true ] && insecure_registry_flag="--insecure"
   [ "$supports_no_resolve_image" = true ] && no_resolve_image_flag="--no-resolve-image"
 
-  if [[ -n "$registry_user" ]]; then
-    logger "Trying to login into registry $registry_host"
-    echo "$registry_password" | docker login --username="$registry_user" --password-stdin "$registry_host"
-  fi
+  authenticate_to_registries
 
   for name in $(IFS=$'\n' docker service ls --quiet --filter "${FILTER_SERVICES}" --format '{{.Name}}'); do
-    local image_with_digest image
+    local image_with_digest image auth_config config_flag
     if [[ " $ignorelist " != *" $name "* ]]; then
       image_with_digest="$(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
       image=$(echo "$image_with_digest" | cut -d@ -f1)
+      auth_config=$(docker service inspect "$name" -f '{{index .Spec.Labels "shepherd.auth.config"}}')
+      if [[ -z "$auth_config" ]]; then
+          config_flag=()
+      else
+          config_flag=(--config "$auth_config")
+      fi
 
-      if ! DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $insecure_registry_flag "$image" > /dev/null; then
+      if ! DOCKER_CLI_EXPERIMENTAL=enabled docker "${config_flag[@]}" manifest inspect $insecure_registry_flag "$image" > /dev/null; then
         logger "Error updating service $name! Image $image does not exist or it is not available"
       else
         logger "Trying to update service $name with image $image" "true"
 
 	# shellcheck disable=SC2086
-        if ! docker service update "$name" $detach_option $registry_auth $no_resolve_image_flag ${UPDATE_OPTIONS} --image="$image" > /dev/null; then
+        if ! docker "${config_flag[@]}" service update "$name" $detach_option $registry_auth $no_resolve_image_flag ${UPDATE_OPTIONS} --image="$image" > /dev/null; then
           logger "Service $name update failed on $hostname!"
           if [[ "${ROLLBACK_ON_FAILURE+x}" ]]; then
             logger "Rolling $name back"
 	    # shellcheck disable=SC2086
-            docker service update "$name" $detach_option $registry_auth $no_resolve_image_flag ${ROLLBACK_OPTIONS} --rollback > /dev/null
+            docker "${config_flag[@]}" service update "$name" $detach_option $registry_auth $no_resolve_image_flag ${ROLLBACK_OPTIONS} --rollback > /dev/null
           fi
           if [[ "$apprise_sidecar_url" != "" ]]; then
             title="[Shepherd] Service $name update failed on $hostname"


### PR DESCRIPTION
I saw you merged my previous PR while I was finalizing this. 
It makes it possible to have all authentication info in a docker secret file, and it also allows authenticating to one registry with different accounts. This last point requires the container to be updated to be labeled accordingly to identify which authentication information to use. See the README changes for details. Let me know what you think, it works fine for me.