### PR TITLE
Add option for a fixed time 24h, 48h, ... schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ A Docker swarm service for automatically updating your services whenever their b
 
 ### Configuration
 
-Shepherd will try to update your services every 5 minutes by default. You can adjust this value using the `SLEEP_TIME` variable.
+Shepherd will try to update your services every 5 minutes by default. You can adjust this value using the `SLEEP_TIME` variable. 
+
+As an alternative you can set `SLEEP_UNTIL` to specify a fixed time when the services should be updated. If `SLEEP_UNTIL` is set, any value in `SLEEP_TIME` is ignored. `SLEEP_UNTIL` uses a 24-hour time format with the option to specify additional days: `HH[:MM[:SS]] [add days]`. This allows 24h, 48h, 72h, ... schedules that run at a fixed time. Examples: 23 --> every day at 23:00:00; 13:30:10 2 --> every third day at 13:30:10 
 
 You can prevent services from being updated by appending them to the `IGNORELIST_SERVICES` variable. This should be a space-separated list of service names.
 

--- a/shepherd
+++ b/shepherd
@@ -151,13 +151,13 @@ sleep_until() {
   local timezone_offset now
   local -a hours_minutes_seconds_days=(${SLEEP_UNTIL//:/ })
   printf -v now '%(%s)T' -1
-  printf -v timezone_offset '%(%z)T' $now
-  timezone_offset=$(( 0${timezone_offset:0:1} ( 10#${timezone_offset:1:2} * 3600 + 10#${timezone_offset: -2} * 60 )))
-  sleep_time=$(((( 86400 + ( now - now % 86400 ) + \
-             10#$hours_minutes_seconds_days * 3600 + \
-             10#${hours_minutes_seconds_days[1]:-0} * 60 + \
-             10#${hours_minutes_seconds_days[2]:-0} - timezone_offset - now ) % 86400 ) + \
-             10#${hours_minutes_seconds_days[3]:-0} * 86400 ))
+  printf -v timezone_offset '%(%z)T' "$now"
+  local expr
+  expr="0${timezone_offset:0:1} ( 10#${timezone_offset:1:2} * 3600 + 10#${timezone_offset: -2} * 60 )"
+  timezone_offset=$(( expr ))
+  echo "tz_off: $timezone_offset"
+  expr="(( 86400 + ( now - now % 86400 ) + 10#${hours_minutes_seconds_days} * 3600 + 10#${hours_minutes_seconds_days[1]:-0} * 60 + 10#${hours_minutes_seconds_days[2]:-0} - timezone_offset - now ) % 86400 ) +  10#${hours_minutes_seconds_days[3]:-0} * 86400"
+  sleep_time=$(( expr ))
   logger "$(printf 'Next update at %(%c)T' $((now+sleep_time)))" "true"
 }
 

--- a/shepherd
+++ b/shepherd
@@ -149,7 +149,7 @@ get_registry_password() {
 # examples: '23' --> every day at 23:00:00; '13:30:10 2' --> every third day at 13:30:10; 
 sleep_until() { 
   local timezone_offset now
-  local -a hours_minutes_seconds_days=(${SLEEP_UNTIL//:/ })
+  local -a hours_minutes_seconds_days="(${SLEEP_UNTIL//:/ })"
   printf -v now '%(%s)T' -1
   printf -v timezone_offset '%(%z)T' "$now"
   local expr

--- a/shepherd
+++ b/shepherd
@@ -145,6 +145,22 @@ get_registry_password() {
     fi
 }
 
+# calculates the seconds to the next run. $SLEEP_UNTIL 24-hour time format with additional days: 'HH[:MM[:SS]] [add days]'. 
+# examples: '23' --> every day at 23:00:00; '13:30:10 2' --> every third day at 13:30:10; 
+sleep_until() { 
+  local timezone_offset now
+  local -a hours_minutes_seconds_days=(${SLEEP_UNTIL//:/ })
+  printf -v now '%(%s)T' -1
+  printf -v timezone_offset '%(%z)T' $now
+  timezone_offset=$(( 0${timezone_offset:0:1} ( 10#${timezone_offset:1:2} * 3600 + 10#${timezone_offset: -2} * 60 )))
+  sleep_time=$(((( 86400 + ( now - now % 86400 ) + \
+             10#$hours_minutes_seconds_days * 3600 + \
+             10#${hours_minutes_seconds_days[1]:-0} * 60 + \
+             10#${hours_minutes_seconds_days[2]:-0} - timezone_offset - now ) % 86400 ) + \
+             10#${hours_minutes_seconds_days[3]:-0} * 86400 ))
+  logger "$(printf 'Next update at %(%c)T' $((now+sleep_time)))" "true"
+}
+
 main() {
   local sleep_time supports_detach_option supports_registry_auth verbose image_autoclean_limit ignorelist
   local registry_user=""
@@ -196,7 +212,12 @@ main() {
   else
     while true; do
       update_services "$ignorelist" "$supports_detach_option" "$supports_registry_auth" "$supports_insecure_registry" "$supports_no_resolve_image" "$image_autoclean_limit" "$registry_user" "$registry_password" "$registry_host"
-      logger "Sleeping $sleep_time before next update" "true"
+      if [[ ${SLEEP_UNTIL+x} ]]; then
+        sleep_until
+        logger "Sleeping ${sleep_time} seconds before next update" "true"
+      else
+        logger "Sleeping ${sleep_time} before next update" "true"
+      fi
       sleep "$sleep_time"
     done
   fi


### PR DESCRIPTION
Run the service updates at a specific time.

An environment variable `SLEEP_UNTIL` is introduced, which uses a 24-hour time format with the option to specify additional days: `HH[:MM[:SS]] [add days]`. This allows 24h, 48h, 72h, ... schedules that run at a fixed time. Examples: `23` --> every day at 23:00:00; `13:30:10 2` --> every third day at 13:30:10

If `SLEEP_UNTIL` is set, any value in `SLEEP_TIME` is ignored.