### PR TITLE
Add option for a cron based schedule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mazzolino/docker:20 AS builder
 RUN apk add --update --no-cache git build-base
 
 WORKDIR /git/
-RUN git clone https://github.com/ksh93/ksh.git
+RUN git clone --depth 1 --branch v1.0.4 https://github.com/ksh93/ksh.git
 
 ENV CCFLAGS='-D_BSD_SOURCE -D_DEFAULT_SOURCE'
 RUN ksh/bin/package make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
+FROM mazzolino/docker:20 AS builder
+
+RUN apk add --update --no-cache git build-base
+
+WORKDIR /git/
+RUN git clone https://github.com/ksh93/ksh.git
+
+ENV CCFLAGS='-D_BSD_SOURCE -D_DEFAULT_SOURCE'
+RUN ksh/bin/package make
+RUN ksh/bin/package install /ksh-install/ ksh
+
 FROM mazzolino/docker:20
 
 ENV SLEEP_TIME='5m'
@@ -8,6 +19,8 @@ ENV UPDATE_OPTIONS=''
 ENV ROLLBACK_OPTIONS=''
 
 RUN apk add --update --no-cache bash curl tzdata
+
+COPY --from=builder /ksh-install/bin/ /bin/
 
 COPY shepherd /usr/local/bin/shepherd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM mazzolino/docker:20 AS builder
 
-RUN apk add --update --no-cache git build-base
+RUN apk add --update --no-cache bash build-base git
 
 WORKDIR /git/
 RUN git clone --depth 1 --branch v1.0.4 https://github.com/ksh93/ksh.git
 
 ENV CCFLAGS='-D_BSD_SOURCE -D_DEFAULT_SOURCE'
-RUN ksh/bin/package make
+RUN ksh/bin/package make SHELL=/bin/bash
 RUN ksh/bin/package install /ksh-install/ ksh
 
 FROM mazzolino/docker:20

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A Docker swarm service for automatically updating your services whenever their b
 
 Shepherd will try to update your services every 5 minutes by default. You can adjust this value using the `SLEEP_TIME` variable.
 
-As an alternative you can set `SLEEP_SCHEDULE` to specify fixed time(s) when the services should be updated. If `SLEEP_SCHEDULE` is set, any value in `SLEEP_TIME` is ignored. `SLEEP_SCHEDULE` has to be a valid unix cron schedule of five fields. Example "0 8,16 * * *" --> every day at 08:00 and 16:00
+As an alternative you can set `SLEEP_SCHEDULE` to specify fixed time(s) when the services should be updated. If `SLEEP_SCHEDULE` is set, any value in `SLEEP_TIME` is usually ignored except for implausible values for the next scheduled run. `SLEEP_SCHEDULE` has to be a valid unix cron schedule of five fields. Example "0 8,16 * * *" --> every day at 08:00 and 16:00
 
 You can prevent services from being updated by appending them to the `IGNORELIST_SERVICES` variable. This should be a space-separated list of service names.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ A Docker swarm service for automatically updating your services whenever their b
 
 Shepherd will try to update your services every 5 minutes by default. You can adjust this value using the `SLEEP_TIME` variable.
 
+As an alternative you can set `SLEEP_SCHEDULE` to specify fixed time(s) when the services should be updated. If `SLEEP_SCHEDULE` is set, any value in `SLEEP_TIME` is ignored. `SLEEP_SCHEDULE` has to be a valid unix cron schedule of five fields. Example "0 8,16 * * *" --> every day at 08:00 and 16:00
+
 You can prevent services from being updated by appending them to the `IGNORELIST_SERVICES` variable. This should be a space-separated list of service names.
 
 Alternatively you can specify a filter for the services you want updated using the `FILTER_SERVICES` variable. This can be anything accepted by the filtering flag in `docker service ls`.

--- a/shepherd
+++ b/shepherd
@@ -145,6 +145,16 @@ get_registry_password() {
     fi
 }
 
+# calculates the seconds to the next run. $SLEEP_SCHEDULE has to be a valid unix cron schedule. 
+# example "0 8,16 * * *" --> every day at 08:00 and 16:00
+sleep_until() { 
+  local now next_update
+  now=$( date +%s )
+  next_update=$( ksh -c "printf \"%(%s)T\" \"${SLEEP_SCHEDULE}\"" ) 
+  sleep_time=$(( next_update - now ))
+  logger "Next update at $( date -d @$(( next_update )) )" "true"
+}
+
 main() {
   local sleep_time supports_detach_option supports_registry_auth verbose image_autoclean_limit ignorelist
   local registry_user=""
@@ -196,7 +206,12 @@ main() {
   else
     while true; do
       update_services "$ignorelist" "$supports_detach_option" "$supports_registry_auth" "$supports_insecure_registry" "$supports_no_resolve_image" "$image_autoclean_limit" "$registry_user" "$registry_password" "$registry_host"
-      logger "Sleeping $sleep_time before next update" "true"
+      if [[ ${SLEEP_SCHEDULE+x} ]]; then
+        sleep_until
+        logger "Sleeping ${sleep_time} seconds before next update" "true"
+      else
+        logger "Sleeping ${sleep_time} before next update" "true"
+      fi
       sleep "$sleep_time"
     done
   fi

--- a/shepherd
+++ b/shepherd
@@ -151,12 +151,18 @@ sleep_until() {
   local now next_update
   now=$( date +%s )
   next_update=$( ksh -c "printf \"%(%s)T\" \"${SLEEP_SCHEDULE}\"" ) 
-  sleep_time=$(( next_update - now ))
-  logger "Next update at $( date -d @$(( next_update )) )" "true"
+  schedule_sleep_time=$(( next_update - now ))
+  if (( schedule_sleep_time > 0 )); then
+    logger "Next update at $( date -d @$(( next_update )) )" "true"
+  else
+    logger "Calculated sleep time from schedule not valid: $schedule_sleep_time"
+    logger "Defaulting to SLEEP_TIME: $sleep_time"
+    schedule_sleep_time=$sleep_time
+  fi
 }
 
 main() {
-  local sleep_time supports_detach_option supports_registry_auth verbose image_autoclean_limit ignorelist
+  local sleep_time schedule_sleep_time supports_detach_option supports_registry_auth verbose image_autoclean_limit ignorelist
   local registry_user=""
   local registry_password=""
   local registry_host=""
@@ -208,11 +214,12 @@ main() {
       update_services "$ignorelist" "$supports_detach_option" "$supports_registry_auth" "$supports_insecure_registry" "$supports_no_resolve_image" "$image_autoclean_limit" "$registry_user" "$registry_password" "$registry_host"
       if [[ ${SLEEP_SCHEDULE+x} ]]; then
         sleep_until
-        logger "Sleeping ${sleep_time} seconds before next update" "true"
+        logger "Sleeping ${schedule_sleep_time} seconds before next update" "true"
+        sleep "${schedule_sleep_time}"
       else
         logger "Sleeping ${sleep_time} before next update" "true"
+        sleep "$sleep_time"
       fi
-      sleep "$sleep_time"
     done
   fi
 }


### PR DESCRIPTION
Run the service updates specified by a cron schedule.

An environment variable `SLEEP_SCHEDULE` is introduced, which has to be a valid unix cron schedule of five fields. Example `0 8,16 * * *` --> every day at 08:00 and 16:00

If `SLEEP_SCHEDULE` is set, any value in `SLEEP_TIME` is ignored unless the calculated next schedule time is an implausible value. Then it defaults to `SLEEP_TIME`.

Because I have not found the Korn Shell ksh93 in an alpine repository it is compiled and copied to the final image during the docker multi-stage build. 