### PR TITLE
Add documentation about `REGISTRIES_FILE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ Create and edit that file locally, eg at the location `private/shepherd-registri
 ```
 docker secret create shepherd-registries-auth private/shepherd-registries-auth
 ```
-You need to make the secret available to shepherd with the `secrets` key:
+You need to make the secret available to shepherd with the `secrets` key, and pass the secret file to the `REGISTRIES_FILE` variable:
 ```
 services:
   app:
     image: mazzolino/shepherd
+    environment:
+      REGISTRIES_FILE: /var/run/secrets/shepherd-registries-auth
     secrets:
       - shepherd-registries-auth
 secrets:


### PR DESCRIPTION
In case the user use secret, the code reference the `REGISTRIES_FILE`, but secret by itself is not used at all by default. Either the code auto detect secret file, or without changing the code, we need to set the `REGISTRIES_FILE` to the secret file in order to pick it.